### PR TITLE
workflowファイルの追加

### DIFF
--- a/.github/workflows/Build_Meridian_LITE.yml
+++ b/.github/workflows/Build_Meridian_LITE.yml
@@ -1,0 +1,25 @@
+name: Build Meridian_LITE
+on:
+  workflow_dispatch:
+    inputs:
+      board_env:
+        description: 'Select environments'
+        required: true
+        default: 'Meridian_LITE_for_ESP32'
+        type: choice
+        options:
+          - Meridian_LITE_for_ESP32
+      build_flags:
+        description: 'Build flags'
+        required: false
+        type: string
+
+jobs:
+  Meridian_LITE_for_ESP32:
+    if: github.event.inputs.board_env == 'Meridian_LITE_for_ESP32'
+    uses: ./.github/workflows/_WORKFLOW_CALL_RunningPlatformIO.yml
+    with:
+      target_dir: Meridian_LITE_for_ESP32
+      board_env: esp32dev
+      build_flags: ${{inputs.build_flags}}
+      firmware_name: esp32dev_firmware

--- a/.github/workflows/Check_PullRequest.yml
+++ b/.github/workflows/Check_PullRequest.yml
@@ -1,0 +1,14 @@
+name: Check pull request
+on:
+  pull_request:
+    branches:
+    - main
+    - develop
+
+jobs:
+  Meridian_LITE_for_ESP32:
+    uses: ./.github/workflows/_WORKFLOW_CALL_RunningPlatformIO.yml
+    with:
+      target_dir: Meridian_LITE_for_ESP32
+      board_env: esp32dev
+      firmware_name: esp32dev_firmware

--- a/.github/workflows/Create_ReleaseNote.yml
+++ b/.github/workflows/Create_ReleaseNote.yml
@@ -1,0 +1,60 @@
+name: Create Release Note
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  Build_Meridian_LITE_for_ESP32:
+    uses: ./.github/workflows/_WORKFLOW_CALL_RunningPlatformIO.yml
+    with:
+      target_dir: Meridian_LITE_for_ESP32
+      board_env: esp32dev
+      firmware_name: Meridian_LITE_for_ESP32
+
+  build:
+    permissions:
+      contents: write
+    if: success()
+    needs: Build_Meridian_LITE_for_ESP32
+    name: Build Releases on tags
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Read current version
+      id: current_version
+      run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+    - name: Download All Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+        pattern: Meridian_LITE_*
+        merge-multiple: true
+
+    - name: List all artifacts
+      run: ls -R artifacts
+
+    - name: Create Release Note
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.current_version.outputs.TAG }}
+        release_name: "Meridian_LITE ${{ steps.current_version.outputs.TAG }}"
+        body: |
+          ## This is a sample file for checking operation.
+        draft: true
+        prerelease: false
+
+    - name: Upload Release Asset (Meridian_LITE_for_ESP32)
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{github.workspace}}/artifacts/Meridian_LITE_for_ESP32.bin
+        asset_name: Meridian_LITE_for_ESP32.bin
+        asset_content_type: application/bin

--- a/.github/workflows/_WORKFLOW_CALL_RunningPlatformIO.yml
+++ b/.github/workflows/_WORKFLOW_CALL_RunningPlatformIO.yml
@@ -1,0 +1,63 @@
+name: Running PlatformIO
+on:
+  workflow_call:
+    inputs:
+      target_dir:
+        required: true
+        type: string
+      board_env:
+        required: true
+        type: string
+      build_flags:
+        description: 'Build flags'
+        required: false
+        type: string
+        default: ''
+      firmware_name:
+        description: 'Firmware name'
+        required: false
+        type: string
+        default: 'firmware'
+
+jobs:
+  build:
+    name: Running PlatformIO
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout my project
+      uses: actions/checkout@v4
+
+    - name: Cache PlatformIO dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{github.workspace}}/${{inputs.target_dir}}/.cache/pip
+          ${{github.workspace}}/${{inputs.target_dir}}/.platformio/.cache
+        key: ${{ runner.os }}-pio
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install PlatformIO Core
+      working-directory: ${{github.workspace}}/${{inputs.target_dir}}
+      run: pip install --upgrade platformio
+
+    - name: Build PlatformIO Project
+      working-directory: ${{github.workspace}}/${{inputs.target_dir}}
+      run: pio run -e ${{inputs.board_env}}
+      env:
+        PLATFORMIO_BUILD_FLAGS: ${{inputs.build_flags}}
+
+    - name: Rename firmware.bin
+      if: success() && '${{inputs.firmware_name}}' != 'firmware'
+      working-directory: ${{github.workspace}}/${{inputs.target_dir}}/.pio/build/${{inputs.board_env}}
+      run: cp firmware.bin ${{inputs.firmware_name}}.bin
+
+    - name: Upload artifacts
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{inputs.firmware_name}}
+        path: ${{github.workspace}}/${{inputs.target_dir}}/.pio/build/${{inputs.board_env}}/${{inputs.firmware_name}}.bin
+        overwrite: true


### PR DESCRIPTION
GitHub Actionで使用できるWorkflowファイルです。
これを追加することで下記のことが期待できます

*  main/developブランチにプルリクエストで、事前に**ビルドができないソースコードを**把握することができます
  * 関連しているworkflowファイル：.github/workflows/Check_PullRequest.yml
* リリースノートを発行するテンプレートファイルを作成できます。そのテンプレートにはbinファイルをあらかじめ追加できます
  * 関連しているworkflowファイル：.github/workflows/Create_ReleaseNote.yml
* PCでビルドができない環境でも、GitHubでbinファイルを作ることができます 
  * 関連しているworkflowファイル：.github/workflows/Build_Meridian_LITE.yml


--- 

下記のファイルは上記のworkflowが呼び出すPlatformIOで実行するテンプレートworkflowです

* .github/workflows/_WORKFLOW_CALL_RunningPlatformIO.yml
